### PR TITLE
EnableFiltersSubscriber: start filters on ApplicationStartupEvent event

### DIFF
--- a/src/EventSubscriber/EnableFiltersSubscriber.php
+++ b/src/EventSubscriber/EnableFiltersSubscriber.php
@@ -11,6 +11,7 @@ namespace Zenify\DoctrineFilters\EventSubscriber;
 
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\ApplicationStartupEvent;
 use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\PresenterCreatedEvent;
 use Zenify\DoctrineFilters\Contract\FilterManagerInterface;
 
@@ -34,7 +35,7 @@ final class EnableFiltersSubscriber implements EventSubscriberInterface
 	{
 		return [
 			ConsoleEvents::COMMAND => 'enableFilters',
-			PresenterCreatedEvent::NAME => 'enableFilters'
+			ApplicationStartupEvent::NAME => 'enableFilters'
 		];
 	}
 

--- a/tests/EventSubscriber/EnableFiltersSubscriberTest.php
+++ b/tests/EventSubscriber/EnableFiltersSubscriberTest.php
@@ -9,6 +9,7 @@ use Nette\Application\Application;
 use Nette\Application\IPresenter;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\ApplicationStartupEvent;
 use Symplify\SymfonyEventDispatcher\Adapter\Nette\Event\PresenterCreatedEvent;
 use Zenify\DoctrineFilters\Tests\ContainerFactory;
 
@@ -41,11 +42,8 @@ final class EnableFiltersSubscriberTest extends TestCase
 		$this->assertCount(0, $filters->getEnabledFilters());
 
 		$applicationMock = $this->prophesize(Application::class);
-		$presenterMock = $this->prophesize(IPresenter::class);
-		$applicationPresenterEvent = new PresenterCreatedEvent(
-			$applicationMock->reveal(), $presenterMock->reveal()
-		);
-		$this->eventDispatcher->dispatch(PresenterCreatedEvent::NAME, $applicationPresenterEvent);
+		$applicationStartupEvent = new ApplicationStartupEvent($applicationMock->reveal());
+		$this->eventDispatcher->dispatch(ApplicationStartupEvent::NAME, $applicationStartupEvent);
 
 		$this->assertCount(2, $filters->getEnabledFilters());
 	}


### PR DESCRIPTION
In some cases is too late enable filters on `PresenterCreatedEvent`, its better enable them on `ApplicationStartupEvent`.